### PR TITLE
fix: intermittent hang at client shutdown when log/completion callbacks are active

### DIFF
--- a/lib/tb_client.rb
+++ b/lib/tb_client.rb
@@ -277,6 +277,7 @@ module TBClient
 
   attach_function :tb_client_init, [Client.by_ref, :pointer, :string, :uint32, :uint, :on_completion], InitStatus
   attach_function :tb_client_submit, [Client.by_ref, Packet.by_ref], ClientStatus
-  attach_function :tb_client_deinit, [Client.by_ref], ClientStatus
+  # Release the GVL during shutdown so FFI callback-runner threads can run completion/log procs.
+  attach_function :tb_client_deinit, [Client.by_ref], ClientStatus, blocking: true
   attach_function :tb_client_register_log_callback, [:log_handler, :bool], RegisterLogCallbackStatus
 end


### PR DESCRIPTION
# Use blocking FFI for `tb_client_deinit` to avoid shutdown deadlock

## Background

`TigerBeetle::Client` registers FFI callbacks at init (`on_completion` for request results, optional `log_handler` when a logger is set). Completions and logs are delivered on FFI callback-runner threads, which need the Ruby GVL to enter Ruby.

`tb_client_deinit` was attached without `blocking: true`, so the calling thread keeps the GVL for the entire native shutdown. If the native client invokes completion or log callbacks during teardown (or a callback runner is still finishing work from a prior request), the main thread can block in `deinit` while callback threads block waiting for the GVL - an intermittent hang at process exit (`at_exit { deinit }`).

This showed up in production-style workloads: multi-replica TigerBeetle, rake tasks that exit immediately after the last request, and DEBUG logging (which increases `log_handler` traffic). Repro pattern: concurrent submits + `at_exit` deinit without returning.

## Summary

Attach `tb_client_deinit` with `blocking: true` so the GVL is released for the duration of native shutdown, allowing FFI callback-runner threads to run completion/log procs. No API or behavior change for callers; only shutdown synchronization.

## Changes

- `lib/tb_client.rb`: `attach_function :tb_client_deinit, ..., blocking: true` with a short comment.

## Notes for reviewers

- `tb_client_submit` remains non-blocking; only `deinit` needs this because it is a long-running shutdown path that can synchronize with callback threads.
- Aligns with FFI guidance: native calls that may trigger Ruby callbacks should release the GVL (`blocking: true`).

